### PR TITLE
Fix compiling error when enable debug

### DIFF
--- a/src/components/tl/rccl/tl_rccl_coll.c
+++ b/src/components/tl/rccl/tl_rccl_coll.c
@@ -140,7 +140,9 @@ ucc_status_t ucc_tl_rccl_coll_finalize(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_rccl_collective_sync(ucc_tl_rccl_task_t *task,
                                          hipStream_t stream)
 {
-  //   ucc_tl_rccl_context_t *ctx    = TASK_CTX(task);
+#if ENABLE_DEBUG == 1
+    ucc_tl_rccl_context_t *ctx    = TASK_CTX(task);
+#endif
     ucc_status_t           status = UCC_OK;
 
     task->host_status = task->super.super.status;


### PR DESCRIPTION
## What
`ucc_tl_rccl_context_t *ctx` was not defined but is used by `ucc_assert`. It caused compilation error (see below).
```
../../../../../src/components/tl/rccl/tl_rccl_coll.c: In function ‘ucc_tl_rccl_collective_sync’:
../../../../../src/components/tl/rccl/tl_rccl_coll.c:149:16: error: ‘ctx’ undeclared (first use in this function)
     ucc_assert(ctx->cfg.sync_type == UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT);
```

 This commit fixes it. `ctx` will be defined when debug build is on (configure with --enable-debug)

